### PR TITLE
Fix HTTP response order and error logging

### DIFF
--- a/go/cmd/todo_app/main.go
+++ b/go/cmd/todo_app/main.go
@@ -23,12 +23,12 @@ func main() {
 
 	router.Route("/api/v1", func(r chi.Router) {
 		r.Get("/test", func(w http.ResponseWriter, r *http.Request) {
-			w.Write([]byte("Hello World\n"))
 			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("Hello World\n"))
 		})
 		r.Post("/todos/", func(w http.ResponseWriter, r *http.Request) {
-			w.Write([]byte("Hello World\n"))
 			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("Hello World\n"))
 		})
 	})
 
@@ -38,6 +38,6 @@ func main() {
 	}
 
 	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-		fmt.Println("サーバー起動に失敗しました: %v", err)
+		fmt.Printf("サーバー起動に失敗しました: %v\n", err)
 	}
 }


### PR DESCRIPTION
## Summary
- ensure status code is written before response body
- log server startup errors using formatted output

## Testing
- `npm test` *(fails: `jest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684a0559d26c8329860d4fe884fc5064