### PR TITLE
Fix interface typo

### DIFF
--- a/front/src/features/todoInput/components/formParts/period/TodoPeriodFromInput.tsx
+++ b/front/src/features/todoInput/components/formParts/period/TodoPeriodFromInput.tsx
@@ -1,10 +1,10 @@
 import { StandardDatePicker } from '@/components'
 
-interface TodoPeriodFromtInputProps {
+interface TodoPeriodFromInputProps {
   name: string
 }
 
-function TodoPeriodFromInput(props: TodoPeriodFromtInputProps) {
+function TodoPeriodFromInput(props: TodoPeriodFromInputProps) {
   const { name } = props
   return <StandardDatePicker name={name} rules={{ required: '開始日を入力してください' }}>開始日</StandardDatePicker>
 }


### PR DESCRIPTION
## Summary
- rename `TodoPeriodFromtInputProps` to `TodoPeriodFromInputProps`
- update `TodoPeriodFromInput` parameter type

## Testing
- `npm test` *(fails: jest not found)*
- `go test ./...` *(fails: network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_684a0713dc1c8329809103f2afc9b2e6