### PR TITLE
Add reset test for TodoInputForm

### DIFF
--- a/front/src/features/todoInput/__tests__/integration/TodoInputForm.spec.tsx
+++ b/front/src/features/todoInput/__tests__/integration/TodoInputForm.spec.tsx
@@ -92,4 +92,25 @@ describe('TodoInputForm', () => {
 
     expect(dateToInput).toHaveValue(dayjs('2025/02/27').format('YYYY/MM/DD'))
   })
+
+  it('送信後に入力値が初期値に戻る', async () => {
+    const {
+      titleInput,
+      descriptionInput,
+      dateFromInput,
+      dateToInput,
+      submitButton,
+    } = setup()
+
+    await userEvent.type(titleInput, '社会の勉強')
+    await userEvent.type(descriptionInput, '年号を暗記する')
+    await userEvent.type(dateFromInput, '20250101')
+    await userEvent.type(dateToInput, '20250102')
+    await userEvent.click(submitButton)
+
+    expect(titleInput).toHaveValue('')
+    expect(descriptionInput).toHaveValue('')
+    expect(dateFromInput).toHaveValue(dayjs().format('YYYY/MM/DD'))
+    expect(dateToInput).toHaveValue(dayjs().format('YYYY/MM/DD'))
+  })
 })


### PR DESCRIPTION
## Summary
- add integration test ensuring TodoInputForm resets inputs after submit

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a07917d6c832997cf31acaeaf74bc