### PR TITLE
Move todos POST route to internal package

### DIFF
--- a/go/cmd/todo_app/main.go
+++ b/go/cmd/todo_app/main.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/cors"
+
+	routerPkg "example.com/templateReactGo/internal/router"
 )
 
 func main() {
@@ -26,10 +28,7 @@ func main() {
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte("Hello World\n"))
 		})
-		r.Post("/todos/", func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusOK)
-			w.Write([]byte("Hello World\n"))
-		})
+		routerPkg.RegisterTodoRoutes(r)
 	})
 
 	srv := &http.Server{

--- a/go/internal/router/todos.go
+++ b/go/internal/router/todos.go
@@ -1,0 +1,15 @@
+package router
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// RegisterTodoRoutes registers routes related to todos.
+func RegisterTodoRoutes(r chi.Router) {
+	r.Post("/todos/", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("Hello World\n"))
+	})
+}


### PR DESCRIPTION
## Summary
- extract `POST /api/v1/todos/` endpoint into `internal/router`
- update main to use the new router package

## Testing
- `go test ./...` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684a0bbc298c832983a68bfe4decb613