### PR TITLE
Fix go module path

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -1,4 +1,4 @@
-module example.com/templateReactGo
+module github.com/teruyoshi/todoApp
 
 go 1.24.0
 


### PR DESCRIPTION
## Summary
- update module name to `github.com/teruyoshi/todoApp`

## Testing
- `go fmt ./...` *(fails: go toolchain download forbidden)*
- `go test ./...` *(fails: go toolchain download forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684a945e75008329890a3708dbb35c35