### PR TITLE
Implement todo create handler

### DIFF
--- a/go/internal/features/todoCreate/handler/http.go
+++ b/go/internal/features/todoCreate/handler/http.go
@@ -1,0 +1,30 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// Todo represents the structure of the todo JSON sent from the frontend.
+type Todo struct {
+	TodoTitle       string `json:"todoTitle"`
+	TodoDescription string `json:"todoDescription"`
+	TodoDateFrom    string `json:"todoDateFrom"`
+	TodoDateTo      string `json:"todoDateTo"`
+}
+
+// Create handles the creation of a todo.
+// It simply echoes back the received JSON.
+func Create(w http.ResponseWriter, r *http.Request) {
+	var t Todo
+	if err := json.NewDecoder(r.Body).Decode(&t); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(t); err != nil {
+		http.Error(w, "failed to encode json", http.StatusInternalServerError)
+		return
+	}
+}


### PR DESCRIPTION
## Summary
- add a handler that decodes incoming todo JSON and echoes it back

## Testing
- `go fmt ./...` *(fails: Forbidden)*
- `gofmt -w go/internal/features/todoCreate/handler/http.go`

------
https://chatgpt.com/codex/tasks/task_e_684a9d25d004832996d60d6b3139afe2