### PR TITLE
Add Todo entity for JSON parsing

### DIFF
--- a/go/internal/features/todoCreate/entity/todo.go
+++ b/go/internal/features/todoCreate/entity/todo.go
@@ -1,0 +1,9 @@
+package entity
+
+// Todo represents a todo item received from the frontend.
+type Todo struct {
+	TodoTitle       string `json:"todoTitle"`
+	TodoDescription string `json:"todoDescription"`
+	TodoDateFrom    string `json:"todoDateFrom"`
+	TodoDateTo      string `json:"todoDateTo"`
+}


### PR DESCRIPTION
## Summary
- add `Todo` entity to parse JSON sent from frontend

## Testing
- `go vet ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684aa494cdd88329afed0007a9d9ddd3