### PR TITLE
Inject usecase into todo create handler

### DIFF
--- a/go/internal/features/todoCreate/handler/http.go
+++ b/go/internal/features/todoCreate/handler/http.go
@@ -5,12 +5,15 @@ import (
 	"net/http"
 
 	"github.com/teruyoshi/todoApp/internal/features/todoCreate/entity"
+	"github.com/teruyoshi/todoApp/internal/features/todoCreate/usecase"
 )
 
-type todoCreateHandler struct{}
+type todoCreateHandler struct {
+	uc *usecase.TodoCreateUseCase
+}
 
-func NewTodoCreateHandler() *todoCreateHandler {
-	return &todoCreateHandler{}
+func NewTodoCreateHandler(uc *usecase.TodoCreateUseCase) *todoCreateHandler {
+	return &todoCreateHandler{uc: uc}
 }
 
 func (h *todoCreateHandler) Create(w http.ResponseWriter, r *http.Request) {
@@ -20,8 +23,14 @@ func (h *todoCreateHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	todo, err := h.uc.Execute(t)
+	if err != nil {
+		http.Error(w, "failed to create todo", http.StatusInternalServerError)
+		return
+	}
+
 	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(t); err != nil {
+	if err := json.NewEncoder(w).Encode(todo); err != nil {
 		http.Error(w, "failed to encode json", http.StatusInternalServerError)
 		return
 	}

--- a/go/internal/router/todo.go
+++ b/go/internal/router/todo.go
@@ -6,10 +6,12 @@ import (
 	"github.com/go-chi/chi/v5"
 
 	todoCreateHandler "github.com/teruyoshi/todoApp/internal/features/todoCreate/handler"
+	todoCreateUsecase "github.com/teruyoshi/todoApp/internal/features/todoCreate/usecase"
 )
 
 func RegisterTodoRoutes(r chi.Router) {
-	handler := todoCreateHandler.NewTodoCreateHandler()
+	usecase := todoCreateUsecase.NewTodoCreateUsecase()
+	handler := todoCreateHandler.NewTodoCreateHandler(usecase)
 
 	r.Post("/todos/", handler.Create)
 }


### PR DESCRIPTION
## Summary
- inject `TodoCreateUseCase` in `NewTodoCreateHandler`
- call use case in the handler logic
- update router to create the use case and pass it to the handler

## Testing
- `go vet ./...` *(fails: unable to download toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_684abaeab8c0832994bd4e3376922fff