### PR TITLE
Move DB Todo model to repository

### DIFF
--- a/go/internal/features/todoCreate/entity/todo.go
+++ b/go/internal/features/todoCreate/entity/todo.go
@@ -1,8 +1,8 @@
 package entity
 
 type Todo struct {
-	TodoTitle       string `json:"todoTitle" gorm:"column:title"`
-	TodoDescription string `json:"todoDescription" gorm:"column:description"`
-	TodoDateFrom    string `json:"todoDateFrom" gorm:"column:date_from"`
-	TodoDateTo      string `json:"todoDateTo" gorm:"column:date_to"`
+	TodoTitle       string `json:"todoTitle"`
+	TodoDescription string `json:"todoDescription"`
+	TodoDateFrom    string `json:"todoDateFrom"`
+	TodoDateTo      string `json:"todoDateTo"`
 }

--- a/go/internal/features/todoCreate/repository/mysql/repository.go
+++ b/go/internal/features/todoCreate/repository/mysql/repository.go
@@ -14,6 +14,11 @@ type TodoRepository struct {
 	db *gorm.DB
 }
 
+// AutoMigrate runs the schema migration for the provided models.
+func (r *TodoRepository) AutoMigrate(dst ...interface{}) error {
+	return r.db.AutoMigrate(dst...)
+}
+
 func NewTodoRepository(dsn string) (*TodoRepository, error) {
 	db, err := gorm.Open(mysql.Open(dsn), &gorm.Config{})
 	if err != nil {
@@ -23,8 +28,19 @@ func NewTodoRepository(dsn string) (*TodoRepository, error) {
 }
 
 func (r *TodoRepository) Create(t entity.Todo) (entity.Todo, error) {
-	if err := r.db.Create(&t).Error; err != nil {
+	dbModel := TTodo{
+		TodoTitle:       t.TodoTitle,
+		TodoDescription: t.TodoDescription,
+		TodoDateFrom:    t.TodoDateFrom,
+		TodoDateTo:      t.TodoDateTo,
+	}
+	if err := r.db.Create(&dbModel).Error; err != nil {
 		return entity.Todo{}, err
 	}
-	return t, nil
+	return entity.Todo{
+		TodoTitle:       dbModel.TodoTitle,
+		TodoDescription: dbModel.TodoDescription,
+		TodoDateFrom:    dbModel.TodoDateFrom,
+		TodoDateTo:      dbModel.TodoDateTo,
+	}, nil
 }

--- a/go/internal/features/todoCreate/repository/mysql/ttodo.go
+++ b/go/internal/features/todoCreate/repository/mysql/ttodo.go
@@ -1,0 +1,13 @@
+package mysql
+
+// TTodo represents the DB model for todo table.
+type TTodo struct {
+	TodoTitle       string `gorm:"column:title"`
+	TodoDescription string `gorm:"column:description"`
+	TodoDateFrom    string `gorm:"column:date_from"`
+	TodoDateTo      string `gorm:"column:date_to"`
+}
+
+func (TTodo) TableName() string {
+	return "todos"
+}

--- a/go/internal/router/todo.go
+++ b/go/internal/router/todo.go
@@ -21,6 +21,9 @@ func RegisterTodoRoutes(r chi.Router) {
 	if err != nil {
 		panic(err)
 	}
+	if err := repo.AutoMigrate(&todoCreateRepoMysql.TTodo{}); err != nil {
+		panic(err)
+	}
 	uc := todoCreateUseCase.NewTodoCreateUseCase(repo)
 	handler := todoCreateHandler.NewTodoCreateHandler(uc)
 


### PR DESCRIPTION
## Summary
- move DB fields out of Todo entity and define TTodo in repository
- convert mysql repository to use new TTodo
- run migration for TTodo in router

## Testing
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684b5d0a8e648329964a47a910bdf952