### PR TITLE
Add todoFetch MySQL repository

### DIFF
--- a/go/internal/features/todoFetch/repository/mysql/repository.go
+++ b/go/internal/features/todoFetch/repository/mysql/repository.go
@@ -1,0 +1,29 @@
+package mysql
+
+import (
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
+)
+
+// TodoRepository provides methods to fetch todos from database.
+type TodoRepository struct {
+	db *gorm.DB
+}
+
+// NewTodoRepository creates a new TodoRepository with the given DSN.
+func NewTodoRepository(dsn string) (*TodoRepository, error) {
+	db, err := gorm.Open(mysql.Open(dsn), &gorm.Config{})
+	if err != nil {
+		return nil, err
+	}
+	return &TodoRepository{db: db}, nil
+}
+
+// Fetch retrieves all todos from t_todos and returns them as a slice of TTodo.
+func (r *TodoRepository) Fetch() ([]TTodo, error) {
+	var todos []TTodo
+	if err := r.db.Model(&TTodo{}).Find(&todos).Error; err != nil {
+		return nil, err
+	}
+	return todos, nil
+}

--- a/go/internal/features/todoFetch/repository/mysql/t_todo.go
+++ b/go/internal/features/todoFetch/repository/mysql/t_todo.go
@@ -1,0 +1,14 @@
+package mysql
+
+// TTodo represents the todo entity stored in t_todos table.
+type TTodo struct {
+	TodoTitle       string `gorm:"column:title;type:varchar(20)"`
+	TodoDescription string `gorm:"column:description;type:varchar(200)"`
+	TodoDateFrom    string `gorm:"column:date_from;type:date"`
+	TodoDateTo      string `gorm:"column:date_to;type:date"`
+}
+
+// TableName returns the table name for gorm.
+func (TTodo) TableName() string {
+	return "t_todos"
+}


### PR DESCRIPTION
## Summary
- implement new feature `todoFetch` repository
- add `TTodo` schema for fetching existing todos
- provide `TodoRepository` with `Fetch` method and constructor

## Testing
- `go fmt ./...` *(fails: access denied)*
- `gofmt -w internal/features/todoFetch/repository/mysql/*.go`

------
https://chatgpt.com/codex/tasks/task_e_684bdff237388329b27503c95f6665f6