### PR TITLE
Move Fetch method to todos repository

### DIFF
--- a/go/internal/features/todoFetch/repository/mysql/repository.go
+++ b/go/internal/features/todoFetch/repository/mysql/repository.go
@@ -18,12 +18,3 @@ func NewTodoRepository(dsn string) (*TodoRepository, error) {
 	}
 	return &TodoRepository{db: db}, nil
 }
-
-// Fetch retrieves all todos from t_todos and returns them as a slice of TTodo.
-func (r *TodoRepository) Fetch() ([]TTodo, error) {
-	var todos []TTodo
-	if err := r.db.Model(&TTodo{}).Find(&todos).Error; err != nil {
-		return nil, err
-	}
-	return todos, nil
-}

--- a/go/internal/features/todos/repository/interface.go
+++ b/go/internal/features/todos/repository/interface.go
@@ -4,4 +4,5 @@ import "github.com/teruyoshi/todoApp/internal/features/todos/entity"
 
 type TodoRepository interface {
 	Create(t entity.Todo) (entity.Todo, error)
+	Fetch() ([]entity.Todo, error)
 }

--- a/go/internal/features/todos/repository/mysql/repository.go
+++ b/go/internal/features/todos/repository/mysql/repository.go
@@ -43,3 +43,22 @@ func (r *TodoRepository) Create(t entity.Todo) (entity.Todo, error) {
 		TodoDateTo:      dbModel.TodoDateTo,
 	}, nil
 }
+
+// Fetch retrieves all todos from t_todos and returns them as a slice of entity.Todo.
+func (r *TodoRepository) Fetch() ([]entity.Todo, error) {
+	var dbModels []TTodo
+	if err := r.db.Model(&TTodo{}).Find(&dbModels).Error; err != nil {
+		return nil, err
+	}
+
+	todos := make([]entity.Todo, len(dbModels))
+	for i, m := range dbModels {
+		todos[i] = entity.Todo{
+			TodoTitle:       m.TodoTitle,
+			TodoDescription: m.TodoDescription,
+			TodoDateFrom:    m.TodoDateFrom,
+			TodoDateTo:      m.TodoDateTo,
+		}
+	}
+	return todos, nil
+}


### PR DESCRIPTION
## Summary
- move Fetch method from todoFetch repository to todos repository
- expose Fetch through the todos repository interface

## Testing
- `go test ./...` *(fails: unable to download golang toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_684d38d943b08329accebb768a47116c