### PR TITLE
Add failing RegisterTodoRoutes test

### DIFF
--- a/go/internal/router/todo_test.go
+++ b/go/internal/router/todo_test.go
@@ -1,0 +1,20 @@
+package router
+
+import (
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func TestRegisterTodoRoutes_PanicsOnInvalidDSN(t *testing.T) {
+	t.Setenv("DATABASE_USER", "invalid")
+	t.Setenv("DATABASE_PASSWORD", "invalid")
+	t.Setenv("DATABASE_DBNAME", string(rune(0))) // cause invalid DSN
+	r := chi.NewRouter()
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic when repository initialization fails")
+		}
+	}()
+	RegisterTodoRoutes(r)
+}


### PR DESCRIPTION
## Summary
- add test for router's `RegisterTodoRoutes`

## Testing
- `go test ./...` *(fails: golang toolchain download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684d393829e88329904bc5b036b4b873