### PR TITLE
Improve handler testability

### DIFF
--- a/go/internal/features/todos/handler/http.go
+++ b/go/internal/features/todos/handler/http.go
@@ -8,11 +8,15 @@ import (
 	"github.com/teruyoshi/todoApp/internal/features/todos/usecase"
 )
 
+// todoCreateHandler handles HTTP requests for creating todos.
+// It depends on the TodoCreator interface which makes it easy to
+// replace the actual use case with a stub in tests.
 type todoCreateHandler struct {
-	uc *usecase.TodoCreateUseCase
+	uc usecase.TodoCreator
 }
 
-func NewTodoCreateHandler(uc *usecase.TodoCreateUseCase) *todoCreateHandler {
+// NewTodoCreateHandler constructs a handler with the given use case.
+func NewTodoCreateHandler(uc usecase.TodoCreator) *todoCreateHandler {
 	return &todoCreateHandler{uc: uc}
 }
 

--- a/go/internal/features/todos/usecase/create.go
+++ b/go/internal/features/todos/usecase/create.go
@@ -5,6 +5,13 @@ import (
 	repo "github.com/teruyoshi/todoApp/internal/features/todos/repository"
 )
 
+// TodoCreator represents an interactor capable of creating todos.
+// It allows handlers to depend on behavior instead of a concrete
+// implementation which improves testability.
+type TodoCreator interface {
+	Execute(entity.Todo) (entity.Todo, error)
+}
+
 type TodoCreateUseCase struct {
 	repo repo.TodoRepository
 }


### PR DESCRIPTION
## Summary
- make todo handler depend on a new `usecase.TodoCreator` interface
- update tests to stub the use case instead of the repository

## Testing
- `npm test` *(fails: package.json missing)*
- `go test ./...` *(fails: cannot download Go toolchain due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_684d46d940588329a51013cbf44ce47d